### PR TITLE
pinned the nltk to >=3.9 for enshuring correct version far away from breaking change in 3.8.1/3.8.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4141,4 +4141,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6cf59dedc489e95cd565fe0d634f029ede00bce09f75a458a933fb6e3ca36bee"
+content-hash = "a710e2d1ae01500bab5234aafa3267374905ee7c7be3baea0fcad4acb4cbb1b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ psycopg2-binary = "2.9.9"
 json-log-formatter = "^1.0"
 transformers = "^4.41.2"
 torch = "^2.3.1"
-nltk = "^3.8.1"
+nltk = ">=3.9"
 sqlparse = "^0.5.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Changed the NLTK Version in the dependencies.

In 3.8.2 NLTK introducued a breaking change with introducing punkt_tab as tokenizer source. 

more info on the change: 
https://github.com/nltk/nltk/issues/3293

so with pinning the version to >=3.9 all troubles should be solved and the new function should work as expected.

- please test on your local environment before merging. Also take care of at least have python3.10 installed (3.11 or 3.12 would be better) and used.