### PR TITLE
fixed the document processor

### DIFF
--- a/libs/analitiq/utils/document_processor.py
+++ b/libs/analitiq/utils/document_processor.py
@@ -192,15 +192,22 @@ def chunk_text(
     chunks = []
 
     start = 0
+    previous_end = 0
     while start < text_length:
-        # Find the next token after the chunk size
         end = start + chunk_size
         if end < text_length:
             end = text.rfind(token, start, end)
+            if previous_end == end:
+                end = text.rfind(token, end + 1, start + chunk_size)
             if end == -1:
                 end = min(start + chunk_size, text_length)
+        if end > text_length:
+            end = text_length
         chunks.append(text[start:end])
         start = end + 1 - chunk_overlap
+        if end >= text_length:
+            break
+        previous_end = end
 
     return chunks
 

--- a/libs/tests/unit/utils/test_document_processors.py
+++ b/libs/tests/unit/utils/test_document_processors.py
@@ -23,10 +23,10 @@ def test_chunk_text():
     """TEst the chunk function."""
     text = "This is a test text, it should be split into chunks. please chunk it in a better way."
     expected = [
-        "This is a test text, it should",
-        ",hould be split into chunks. pl",
-        ",s. please chunk it in a better",
-        ",etter way.",
+        "This is a test text",
+        "text, it should be split into ",
+        "nto chunks. please chunk it in",
+        "t in a better way.",
     ]
 
     result = document_processor.chunk_text(text, chunk_size=30, chunk_overlap=5, token=",")


### PR DESCRIPTION
solved handling that the chunk size is always resetting into the  old start and enforcing to ignore the previous splitter token to not end in a deadlock.